### PR TITLE
Do not check entry_size if using latest version.

### DIFF
--- a/pyosudbreader.py
+++ b/pyosudbreader.py
@@ -201,7 +201,10 @@ class OsuDbReader(BasicDbReader):
         """
         if len(self.beatmaps) >= self.num_beatmaps:
             return
-        entry_size = self.read_int()
+        if(self.version<=20191106):
+            entry_size = self.read_int()
+        else:
+            entry_size = None
         artist = self.read_string()
         artist_unicode = self.read_string()
         title = self.read_string()


### PR DESCRIPTION
removed in version 20191106. Instead of removing it entirely which might break compatibility I set it to None if using the latest version.